### PR TITLE
Pass 65536 length to splice instead of usize::MAX

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -149,7 +149,7 @@ where
             ready!(stream.poll_read_ready_n(cx))?;
 
             let res = stream.try_io_n(Interest::READABLE, || {
-                match splice(stream.as_raw_fd(), self.buf.write_fd(), usize::MAX) {
+                match splice(stream.as_raw_fd(), self.buf.write_fd(), 65536) {
                     size if size >= 0 => Ok(size as usize),
                     _ => {
                         let err = Error::last_os_error();


### PR DESCRIPTION
Tested by splicing two TCP sockets together: works on kernel 6.5.0, fails with error EINVAL on kernel 6.8.0.

strace output:
[pid 27024] splice(15, NULL, 19, NULL, 18446744073709551615, SPLICE_F_NONBLOCK) = -1 EINVAL (Invalid argument)

Seems to be related to usize::MAX length passed to syscall splice, this fix use a length of 65536, works on kernel 6.8.0.